### PR TITLE
Refactor argument/command structure

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -75,12 +75,16 @@ jobs:
           sed -i "s|__INWX_OTE_PASS__|${{ secrets.INWX_OTE_PASS }}|" /home/runner/.config/inwx-dns-recordmaster/config.toml
 
       - name: Run with first records configuration
-        run: poetry run inwx-dnsrm -c tests/records/
+        run: poetry run inwx-dnsrm sync -c tests/records/
 
       - name: Run with second records configuration
         run: |
           cp tests/records/test-mehl.mx.yaml.changes tests/records/test-mehl.mx.yaml
-          poetry run inwx-dnsrm -c tests/records/
+          poetry run inwx-dnsrm sync -c tests/records/
+
+      - name: Convert the remote records to YAML
+        run: |
+          poetry run inwx-dnsrm convert -d test-mehl.mx
 
   # Formatting
   pylint:

--- a/README.md
+++ b/README.md
@@ -15,6 +15,21 @@ Manage DNS nameserver records of INWX domains via YAML files and API requests. L
 
 Note: This is no official software project by INWX, it just kindly uses their public API.
 
+- [Overview](#overview)
+- [Install](#install)
+- [Configuration](#configuration)
+  - [App/API configuration](#appapi-configuration)
+  - [DNS records configuration](#dns-records-configuration)
+- [Run the program](#run-the-program)
+  - [Synchronisation mode](#synchronisation-mode)
+  - [Conversion mode](#conversion-mode)
+- [Contribute and Develop](#contribute-and-develop)
+- [Troubleshooting](#troubleshooting)
+  - [Debug and dry-run](#debug-and-dry-run)
+  - [I deleted all my productive records!](#i-deleted-all-my-productive-records)
+  - [Simulate API response](#simulate-api-response)
+- [License](#license)
+
 
 ## Overview
 
@@ -94,7 +109,7 @@ If you already have a domain configured at INWX whose records you want to migrat
 
 You can execute the program using the command `inwx-dnsrm`. `inwx-dnsrm --help` shows all available arguments and options.
 
-The program has two main command: `sync` and `convert`.
+The program has two main commands: `sync` and `convert`.
 
 
 ### Synchronisation mode

--- a/recordmaster/_api.py
+++ b/recordmaster/_api.py
@@ -35,7 +35,7 @@ def _ask_confirmation(question, default="yes") -> bool:
         print("Please respond with 'yes' or 'no' (or 'y' or 'n').")
 
 
-def api_login(debug: bool = False, api_response_file: str = "") -> ApiClient:
+def api_login(api_response_file: str = "", debug: bool = False) -> ApiClient:
     """Login to INWX API"""
     if not api_response_file:
         # Set API URL depending on app config
@@ -97,6 +97,7 @@ def inwx_api(
         )
         sys.exit(1)
     else:
-        raise RuntimeError(f"API call error: {api_result}")
+        logging.error("API call error for '%s' with params '%s': %s", method, params, api_result)
+        sys.exit(1)
 
     return api_result

--- a/recordmaster/_api.py
+++ b/recordmaster/_api.py
@@ -35,7 +35,7 @@ def _ask_confirmation(question, default="yes") -> bool:
         print("Please respond with 'yes' or 'no' (or 'y' or 'n').")
 
 
-def api_login(api_response_file: str, debug: bool) -> ApiClient:
+def api_login(debug: bool = False, api_response_file: str = "") -> ApiClient:
     """Login to INWX API"""
     if not api_response_file:
         # Set API URL depending on app config

--- a/recordmaster/main.py
+++ b/recordmaster/main.py
@@ -86,11 +86,10 @@ parser_convert.add_argument(
 parser.add_argument(
     "-i",
     "--ignore-types",
-    nargs="*",
     default="SOA",
     help=(
-        "Do not delete these types of records when they are only found remotely "
-        "but not locally. Leave empty do consider all types. Example: -i SOA NS."
+        "A comma-separated list of record types which will be ignored when "
+        "considering remote records. Leave empty do consider all types. Example: -i SOA,NS."
     ),
 )
 parser.add_argument(
@@ -246,8 +245,7 @@ def main():
     args = parser.parse_args()
 
     # Convert --ignore-types to list if it's just a string (the default)
-    if not isinstance(args.ignore_types, list):
-        args.ignore_types = [args.ignore_types]
+    args.ignore_types = args.ignore_types.split(",")
 
     # Set logger
     configure_logger(args=args)


### PR DESCRIPTION
This makes the difference between the actual sync and convert feature more clear, and separates the general from the specific options.

Involves a refactoring of the `main()` function which is separated by the commands now and therefore more clear.

Also, it makes the internal API more usable as we no longer rely on argparse namespaces.