### PR TITLE
Handle URL record type

### DIFF
--- a/recordmaster/__init__.py
+++ b/recordmaster/__init__.py
@@ -9,7 +9,21 @@ from importlib.metadata import version
 
 __version__ = version("inwx-dns-recordmaster")
 
-RECORD_KEYS = ("id", "name", "type", "content", "ttl", "prio")
+# All record keys
+RECORD_KEYS = (
+    "id",
+    "name",
+    "type",
+    "content",
+    "ttl",
+    "prio",
+    "urlRedirectType",
+    "urlRedirectTitle",
+    "urlRedirectDescription",
+    "urlRedirectFavIcon",
+    "urlRedirectKeywords",
+    "urlAppend",
+)
 
 DEFAULT_APP_CONFIG = """# App configuration for INWX DNS Recordmaster.
 # This is not the place for domain records, these can be anywhere and used with the -c flag

--- a/recordmaster/_api.py
+++ b/recordmaster/_api.py
@@ -86,6 +86,10 @@ def inwx_api(
         logging.info("API call for '%s' has not been executed in dry-run mode", method)
         return {}
 
+    for key, value in params.items():
+        if isinstance(value, bool):
+            params[key] = 1 if value else 0
+
     api_result = api.call_api(api_method=method, method_params=params)
 
     # Handle return codes

--- a/recordmaster/_data.py
+++ b/recordmaster/_data.py
@@ -18,7 +18,7 @@ from . import RECORD_KEYS
 
 
 @dataclass
-class Record:
+class Record:  # pylint: disable=too-many-instance-attributes
     """Dataclass holding a nameserver record, be it remote or local"""
 
     # nameserver details
@@ -28,6 +28,13 @@ class Record:
     content: str = ""
     ttl: int = 3600
     prio: int = 0
+    # pylint: disable=invalid-name
+    urlRedirectType: str = ""
+    urlRedirectTitle: str = ""
+    urlRedirectDescription: str = ""
+    urlRedirectFavIcon: str = ""
+    urlRedirectKeywords: str = ""
+    urlAppend: bool = False
 
     def import_records(self, data: dict, domain: str = "", root: str = ""):
         """Update records by providing a dict"""
@@ -85,11 +92,12 @@ class Domain:
 
             # Type and content are straightforward, we don't need to convert it
             rec_yaml: dict[str, str | int] = {"type": rec.type, "content": rec.content}
-            # TTL and prio will be set unless it's the default value
-            if rec.ttl != Record.ttl:
-                rec_yaml["ttl"] = rec.ttl
-            if rec.prio != Record.prio:
-                rec_yaml["prio"] = rec.prio
+
+            # All the other attributes unless they have the default value
+            # This is, in RECORD_KEYS, all from the 5th element, ttl
+            for attr in RECORD_KEYS[4:]:
+                if getattr(rec, attr) != getattr(Record, attr):
+                    rec_yaml[attr] = getattr(rec, attr)
 
             data[name].append(rec_yaml)
 

--- a/recordmaster/_sync_records.py
+++ b/recordmaster/_sync_records.py
@@ -17,10 +17,10 @@ def sync_existing_local_to_remote(
     api: ApiClient, domain: Domain, dry: bool, interactive: bool
 ) -> None:
     """Compare previously matched local records to remote ones. If differences, update remote"""
-    # pylint: disable=too-many-nested-blocks
     # Loop over local records which have an ID, so matched to a remote entry
     for loc_rec in [loc_rec for loc_rec in domain.local_records if loc_rec.id]:
         # For each ID, compare content, ttl and prio
+        changes = {}
         for key in ("content", "ttl", "prio"):
             # Get local and corresponding remote attribute
             loc_val = getattr(loc_rec, key)
@@ -33,7 +33,7 @@ def sync_existing_local_to_remote(
             if loc_val and (loc_val != rem_val):
                 # Log and update record
                 logging.info(
-                    "[%s] Updating '%s' record of '%s': '%s' from '%s' to '%s'",
+                    "[%s] Update '%s' record of '%s': '%s' from '%s' to '%s'",
                     domain.name,
                     loc_rec.type,
                     loc_rec.name,
@@ -43,19 +43,23 @@ def sync_existing_local_to_remote(
                 )
 
                 # Update record via API call
-                inwx_api(
-                    api,
-                    "nameserver.updateRecord",
-                    interactive=interactive,
-                    dry=dry,
-                    id=loc_rec.id,
-                    **{key: loc_val},
-                )
+                changes[key] = loc_val
             else:
                 # No action needed as records are equal or undefined
                 logging.debug(
                     "[%s] (%s) %s equal: %s = %s", loc_rec.name, loc_rec.id, key, rem_val, loc_val
                 )
+
+        # Execute collected changes for this ID, if they exist
+        if changes:
+            inwx_api(
+                api,
+                "nameserver.updateRecord",
+                interactive=interactive,
+                dry=dry,
+                id=loc_rec.id,
+                **changes,
+            )
 
 
 def create_missing_at_remote(

--- a/recordmaster/_sync_records.py
+++ b/recordmaster/_sync_records.py
@@ -19,9 +19,9 @@ def sync_existing_local_to_remote(
     """Compare previously matched local records to remote ones. If differences, update remote"""
     # Loop over local records which have an ID, so matched to a remote entry
     for loc_rec in [loc_rec for loc_rec in domain.local_records if loc_rec.id]:
-        # For each ID, compare content, ttl and prio
+        # For each ID, compare content, ttl, prio etc, collect changes, and make API call
         changes = {}
-        for key in ("content", "ttl", "prio"):
+        for key in RECORD_KEYS[3:]:
             # Get local and corresponding remote attribute
             loc_val = getattr(loc_rec, key)
             rem_val = next(


### PR DESCRIPTION
Fixes #20 

Unfortunately, the API seems to be buggy. Changing attributes like `urlAppend` leads to errors:

```
[2024-03-15 17:49:19] INFO: [example.com] Update 'URL' record of 'example.com': 'urlAppend' from 'True' to 'False'
[2024-03-15 17:49:19] DEBUG: Resetting dropped connection: api.domrobot.com
[2024-03-15 17:49:19] DEBUG: https://api.domrobot.com:443 "POST /jsonrpc/ HTTP/1.1" 200 None
Request (nameserver.updateRecord): {"method": "nameserver.updateRecord", "params": {"id": 587719457, "urlAppend": 0}}
Response (nameserver.updateRecord): {"code":2306,"msg":"Parameter value policy error","reasonCode":"Error_NothingToUpdate","reason":"There is nothing to update."}
[2024-03-15 17:49:19] ERROR: API call error for 'nameserver.updateRecord' with params '{'id': 587719457, 'urlAppend': 0}': {'code': 2306, 'msg': 'Parameter value policy error', 'reasonCode': 'Error_NothingToUpdate', 'reason': 'There is nothing to update.'}
```

Changing the `urlRedirectType` on the other side has no effect. This message appears all the time:

```
[2024-03-15 17:50:56] INFO: [example.com] Update 'URL' record of 'www.example.com': 'prio' from '301' to '302'
[2024-03-15 17:50:56] INFO: [example.com] Update 'URL' record of 'www.example.com': 'urlRedirectType' from 'HEADER301' to 'HEADER302'
[2024-03-15 17:50:56] DEBUG: [www.example.com] (587719458) urlRedirectTitle equal:  =
[2024-03-15 17:50:56] DEBUG: [www.example.com] (587719458) urlRedirectDescription equal:  =
[2024-03-15 17:50:56] DEBUG: [www.example.com] (587719458) urlRedirectFavIcon equal:  =
[2024-03-15 17:50:56] DEBUG: [www.example.com] (587719458) urlRedirectKeywords equal:  =
[2024-03-15 17:50:56] DEBUG: [www.example.com] (587719458) urlAppend equal: True = True
[2024-03-15 17:50:56] DEBUG: Resetting dropped connection: api.domrobot.com
[2024-03-15 17:50:56] DEBUG: https://api.domrobot.com:443 "POST /jsonrpc/ HTTP/1.1" 200 None
Request (nameserver.updateRecord): {"method": "nameserver.updateRecord", "params": {"id": 587719458, "prio": 302, "urlRedirectType": "HEADER302"}}
Response (nameserver.updateRecord): {"code":1000,"msg":"Command completed successfully"}
``` 