### PR TITLE
Change type of record.id as INWX API changed it

### DIFF
--- a/recordmaster/_data.py
+++ b/recordmaster/_data.py
@@ -22,7 +22,7 @@ class Record:  # pylint: disable=too-many-instance-attributes
     """Dataclass holding a nameserver record, be it remote or local"""
 
     # nameserver details
-    id: int | None = None
+    id: str | None = None
     name: str = ""
     type: str = ""
     content: str = ""


### PR DESCRIPTION
INWX changed the type of some record IDs. This PR changes the type, but it didn't provoke any issues as far as I could tell.

The announcement email is below.

```
im Rahmen interner technischer Prüfungen haben wir festgestellt, dass die von uns vergebenen DNS-Record-IDs den Grenzwert des 32-Bit Integer-Datentyps überschritten haben.
Die IDs liegen inzwischen über 2,15 Milliarden. Dies führt insbesondere im Zusammenhang mit der XML-RPC API zu technischen Einschränkungen.

Während unsere JSON API große Zahlenwerte problemlos verarbeiten kann, unterstützt der XML-RPC Standard keine 64-Bit Integer. Ein Überschreiten des integer-basierten Wertebereichs führt daher zu fehlerhaften oder negativen Werten, was wiederum Inkompatibilitäten bei bestehenden Clients verursachen kann.

Nach intensiver Prüfung haben wir uns für die Anpassung des Datentyps entschieden. Dies stellt langfristig sicher, dass alle Schnittstellen stabil und standardkonform betrieben werden können.

Die Änderung betrifft ausschließlich den Datentyp der DNS-Record-IDs. Dynamisch typisierte Sprachen wie PHP oder JavaScript sind nicht betroffen. Anpassungsbedarf besteht lediglich bei statisch typisierten Sprachen wie Go.

Folgende API Methoden geben jetzt die DNS-Record-ID als string zurück:

- nameserver.createRecord: output parameter "id"
- nameserver.info: output parameter "record[id]"

Und bei diesen API Methoden muss im XML-RPC Format der string Datentyp gesendet werden:

- nameserver.info: input parameter "recordId"
- nameserver.updateRecord: input parameter "id"
- nameserver.deleteRecord: input parameter "id"
```